### PR TITLE
fix `a[..] .= something`

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}  # optional
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "test"])'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}  # optional
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,4 @@ ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 
 [compat]
 julia = "1.5"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]
+ArrayInterface = "3"

--- a/src/EllipsisNotation.jl
+++ b/src/EllipsisNotation.jl
@@ -71,11 +71,6 @@ ArrayInterface.can_flatten(::Type{A}, ::Type{T}) where {A,T<:Ellipsis} = true
 end
 =#
 
-# avoid copying if indexing with .. alone, see
-# https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/214
-@inline Base.getindex(A::AbstractArray, ::Ellipsis) = A
-@inline ArrayInterface.getindex(A, ::Ellipsis) = A
-
 export ..
 
 end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,6 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+
+[compat]
+ArrayInterface = "3"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -60,6 +60,9 @@ C[..] .= B[..]
 C[1,1] += 1
 @test B != C
 
+@test B[:] == B[..]
+@test B[:] !== B[..]
+
 @testset "ArrayInterface" begin
     A = Array{Int}(undef,2,4,2)
     ArrayInterface.setindex!(A, [2 1 4 5; 2 2 3 6], .., 1)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,3 +1,6 @@
+
+@test isempty(detect_ambiguities(EllipsisNotation))
+
 A = Array{Int}(undef,2,4,2)
 
 A[..,1] = [2 1 4 5
@@ -34,13 +37,25 @@ B = [3 4
 
 # [..]
 C = zero(B)
-
 C[:] = B[..]
 @test B == C
 C[1,1] += 1
 @test B != C
 
+C = zero(B)
 C[..] = B[..]
+@test B == C
+C[1,1] += 1
+@test B != C
+
+C = zero(B)
+C[..] .= B[:]
+@test B == C
+C[1,1] += 1
+@test B != C
+
+C = zero(B)
+C[..] .= B[..]
 @test B == C
 C[1,1] += 1
 @test B != C


### PR DESCRIPTION
I noticed that ab assignment of the form `a[..] .= something` did not work. Hence, I deleted the offending `getindex` overload in EllipsisNotation. The comment there referred to a still open issue that does not seem to be active right now.

If these changes are okay, it would be nice to have a new release.