### PR TITLE
Support for new `is_splat_index` trait

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "EllipsisNotation"
 uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 
 [compat]
-julia = "1.5"
 ArrayInterface = "3"
+julia = "1.5"

--- a/src/EllipsisNotation.jl
+++ b/src/EllipsisNotation.jl
@@ -43,13 +43,11 @@ true
 module EllipsisNotation
 
 using ArrayInterface
-using ArrayInterface: indices
-
 
 import Base: to_indices, tail
 
 struct Ellipsis end
-const ..   = Ellipsis()
+const ..  = Ellipsis()
 
 @inline function to_indices(A, inds::NTuple{M, Any}, I::Tuple{Ellipsis, Vararg{Any, N}}) where {M,N}
     # Align the remaining indices to the tail of the `inds`
@@ -57,10 +55,9 @@ const ..   = Ellipsis()
     to_indices(A, inds, (colons..., tail(I)...))
 end
 
-Base.@propagate_inbounds function ArrayInterface.to_indices(A, inds::Tuple{Vararg{Any,M}}, I::Tuple{Ellipsis,Vararg{Any, N}}) where {M,N}
-    return ArrayInterface.to_indices(A, inds, (ntuple(i -> indices(inds[i]), Val(M-N))..., tail(I)...))
-end
-ArrayInterface.to_indices(A, inds::Tuple{}, I::Tuple{Ellipsis}) = ()
+ArrayInterface.is_splat_index(::Type{Ellipsis}) = ArrayInterface.static(true)
+ArrayInterface.ndims_index(::Type{Ellipsis}) = ArrayInterface.static(1)
+ArrayInterface.to_index(x, ::Ellipsis) = ntuple(i -> ArrayInterface.indices(x, i), Val(ndims(x)))
 
 export ..
 


### PR DESCRIPTION
In addition to the new and faster `ArrayInterface.to_indices` this now accounts for trailing index arguments that map to multiple dimensions (e.g., `A[.., CartesianIndex(2, 2)]`).